### PR TITLE
Fix deprecated navigation callback (MDL-33720)

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -49,7 +49,7 @@ class local_dev_url extends moodle_url {
  * @param global_navigation $navigation the navigation tree instance
  * @category navigation
  */
-function dev_extends_navigation(global_navigation $navigation) {
+function local_dev_extends_navigation(global_navigation $navigation) {
     global $CFG;
 
     if (!empty($CFG->hidelocaldevfromnavigation)) {


### PR DESCRIPTION
On 2.4, debugging says:

Deprecated local plugin navigation callback: Please rename 'dev_extends_navigation' to 'local_dev_extends_navigation'. Support for the old callback will be dropped after the release of 2.4
line 1438 of /lib/navigationlib.php: call to debugging()
line 3176 of /lib/navigationlib.php: call to global_navigation->initialise()
line 700 of /lib/pagelib.php: call to settings_navigation->__construct()
line 717 of /lib/pagelib.php: call to moodle_page->magic_get_settingsnav()
line 6019 of /lib/adminlib.php: call to moodle_page->__get()
line 14 of /admin/upgradesettings.php: call to admin_externalpage_setup()
